### PR TITLE
Build Zinc from published Scala artifacts

### DIFF
--- a/sbt-on-2.10.2
+++ b/sbt-on-2.10.2
@@ -1,42 +1,59 @@
-{"projects":[
-  {
-    name:  "scala",
-    system: "scala",
-    uri:    "git://github.com/scala/scala.git#v2.10.2",
-    set-version: "2.10.2"
-  }, {
-    name:   "scalacheck",
-    uri:    "git://github.com/rickynils/scalacheck.git#1.10.1"
-  }, {
-    name:   "sbinary",
-    uri:    "git://github.com/harrah/sbinary.git"
-    extra: { projects: ["core"] }
-  }, {
-    name:   "sbt",
-    uri:    "git://github.com/sbt/sbt.git#0.13.0"
-    extra: {
-      projects: ["compiler-interface",
-                 "classpath","logging","io","control","classfile",
-                 "process","relation","interface","persist","api",
-                 "compiler-integration","incremental-compiler","compile","launcher-interface"
-                ],
-      run-tests: false
-    }
-  }, {
-    name:   "sbt-republish",
-    uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-    set-version: "0.13.0-on-2.10.2-for-IDE-SNAPSHOT"
-  }, {
-    name:   "zinc",
-    uri:    "https://github.com/typesafehub/zinc.git"
+{
+  build: {
+    "projects":[
+      {
+        name:  "scala-lib",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-library;2.10.2"
+      }, {
+        name:  "scala-compiler",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-compiler;2.10.2"
+      }, {
+        name:  "scala-actors",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-actors;2.10.2"
+      }, {
+        name:  "scala-reflect",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-reflect;2.10.2"
+      }, {
+        name:   "scalacheck",
+        system: "ivy",
+        uri:    "ivy:org.scalacheck#scalacheck_2.10;1.10.1"
+      }, {
+        name:   "sbinary",
+        uri:    "git://github.com/harrah/sbinary.git"
+        extra: { projects: ["core"] }
+      }, {
+        name:   "sbt",
+        uri:    "git://github.com/sbt/sbt.git#0.13.0"
+        extra: {
+          projects: ["compiler-interface",
+                     "classpath","logging","io","control","classfile",
+                     "process","relation","interface","persist","api",
+                     "compiler-integration","incremental-compiler","compile","launcher-interface"
+                    ],
+          run-tests: false
+        }
+      }, {
+        name:   "sbt-republish",
+        uri:    "http://github.com/typesafehub/sbt-republish.git#master",
+        set-version: "0.13.0-on-2.10.2-for-IDE-SNAPSHOT"
+      }, {
+        name:   "zinc",
+        uri:    "https://github.com/typesafehub/zinc.git"
+      }
+    ],
+    options:{cross-version:standard},
   }
-],
-build-options:{cross-version:standard},
-deploy: [
-  {
-    uri="http://private-repo.typesafe.com/typesafe/ide-2.10",
-    credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
-    projects:["sbt-republish"]
+  options: {
+    deploy: [
+      {
+        uri="http://private-repo.typesafe.com/typesafe/ide-2.10",
+        credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
+        projects:["sbt-republish"]
+      }
+    ]
   }
-  ]
 }

--- a/sbt-on-2.10.x
+++ b/sbt-on-2.10.x
@@ -1,43 +1,59 @@
 {
- "projects":[
-  {
-    name:  "scala",
-    system: "scala",
-    uri:    "git://github.com/scala/scala.git#2.10.x",
-    set-version: "2.10.3-SNAPSHOT"
-  }, {
-    name:   "scalacheck",
-    uri:    "git://github.com/rickynils/scalacheck.git#1.10.1"
-  }, {
-    name:   "sbinary",
-    uri:    "git://github.com/harrah/sbinary.git"
-    extra: { projects: ["core"] }
-  }, {
-    name:   "sbt",
-    uri:    "git://github.com/sbt/sbt.git#0.13.0"
-    extra: {
-      projects: ["compiler-interface",
-                 "classpath","logging","io","control","classfile",
-                 "process","relation","interface","persist","api",
-                 "compiler-integration","incremental-compiler","compile","launcher-interface"
-                ],
-      run-tests: false
-    }
-  }, {
-    name:   "sbt-republish",
-    uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-    set-version: "0.13.0-on-2.10.3-SNAPSHOT-for-IDE-SNAPSHOT"
-  }, {
-    name:   "zinc",
-    uri:    "https://github.com/typesafehub/zinc.git"
+  build: {
+    "projects":[
+      {
+        name:  "scala-lib",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-library;2.10.3-SNAPSHOT"
+      }, {
+        name:  "scala-compiler",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-compiler;2.10.3-SNAPSHOT"
+      }, {
+        name:  "scala-actors",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-actors;2.10.3-SNAPSHOT"
+      }, {
+        name:  "scala-reflect",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-reflect;2.10.3-SNAPSHOT"
+      }, {
+        name:   "scalacheck",
+        system: "ivy",
+        uri:    "ivy:org.scalacheck#scalacheck_2.10;1.10.1"
+      }, {
+        name:   "sbinary",
+        uri:    "git://github.com/harrah/sbinary.git"
+        extra: { projects: ["core"] }
+      }, {
+        name:   "sbt",
+        uri:    "git://github.com/sbt/sbt.git#0.13.0"
+        extra: {
+          projects: ["compiler-interface",
+                     "classpath","logging","io","control","classfile",
+                     "process","relation","interface","persist","api",
+                     "compiler-integration","incremental-compiler","compile","launcher-interface"
+                    ],
+          run-tests: false
+        }
+      }, {
+        name:   "sbt-republish",
+        uri:    "http://github.com/typesafehub/sbt-republish.git#master",
+        set-version: "0.13.0-on-2.10.3-SNAPSHOT-for-IDE-SNAPSHOT"
+      }, {
+        name:   "zinc",
+        uri:    "https://github.com/typesafehub/zinc.git"
+      }
+    ],
+    options:{cross-version:standard},
   }
-],
-build-options:{cross-version:standard},
-deploy: [
-  {
-    uri="http://private-repo.typesafe.com/typesafe/ide-2.10",
-    credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
-    projects:["sbt-republish"]
+  options: {
+    deploy: [
+      {
+        uri="http://private-repo.typesafe.com/typesafe/ide-2.10",
+        credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
+        projects:["sbt-republish"]
+      }
+    ]
   }
-  ]
 }

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -1,39 +1,67 @@
-{"projects":[
-  {
-    name: "scala",
-    system: "scala",
-    uri: "git://github.com/scala/scala.git#master",
-    set-version: "2.11.0-SNAPSHOT" // This version should be the one the ide is using/building.
-  }, {
-    name: "sbinary",
-    uri: "git://github.com/harrah/sbinary.git"
-    extra: {
-      projects: ["core"],
-      run-tests: false // Sbinary has some invalid case classes currently.
-    }
-  }, {
-    name: "sbt",
-    uri: "git://github.com/sbt/sbt.git#0.13.0"
-    extra: {
-      projects: ["compiler-interface",
-                 "classpath","logging","io","control","classfile",
-                 "process","relation","interface","persist","api",
-                 "compiler-integration","incremental-compiler","compile","launcher-interface"
-                ],
-      run-tests: false,
-      commands: [ "set every Util.includeTestDependencies := false" ] // Without this, we have to build specs2
-    }
-  }, {
-    name: "sbt-republish",
-    uri: "http://github.com/typesafehub/sbt-republish.git#master",
-    set-version: "0.13.0-on-2.11.0-SNAPSHOT-for-IDE-SNAPSHOT" // This is the version you want to depend on.
+{
+  build: {
+    "projects":[
+      {
+        name:  "scala-lib",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-library;2.11.0-SNAPSHOT"
+      }, {
+        name:  "scala-compiler",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-compiler;2.11.0-SNAPSHOT"
+      }, {
+        name:  "scala-actors",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-actors;2.11.0-SNAPSHOT"
+      }, {
+        name:  "scala-reflect",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-reflect;2.11.0-SNAPSHOT"
+      }, {
+        name:  "scala-xml",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-xml;2.11.0-M4"
+      }, {
+        name:  "scala-parser-combinators",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-parser-combinators;2.11.0-M4"
+      }, {
+        name:   "sbinary",
+        uri:    "git://github.com/harrah/sbinary.git"
+        extra: {
+          projects: ["core"],
+          run-tests: false // Sbinary has some invalid case classes currently.
+        }
+      }, {
+        name:   "sbt",
+        uri:    "git://github.com/sbt/sbt.git#0.13.0"
+        extra: {
+          projects: ["compiler-interface",
+                     "classpath","logging","io","control","classfile",
+                     "process","relation","interface","persist","api",
+                     "compiler-integration","incremental-compiler","compile","launcher-interface"
+                    ],
+          run-tests: false,
+          commands: [ "set every Util.includeTestDependencies := false" ] // Without this, we have to build specs2
+        }
+      }, {
+        name:   "sbt-republish",
+        uri:    "http://github.com/typesafehub/sbt-republish.git#master",
+        set-version: "0.13.0-on-2.11.0-SNAPSHOT-for-IDE-SNAPSHOT"
+      }, {
+        name:   "zinc",
+        uri:    "https://github.com/typesafehub/zinc.git"
+      }
+    ],
+    options:{cross-version:standard},
   }
-],
-deploy: [
-  {
-    uri="http://private-repo.typesafe.com/typesafe/ide-2.11",
-    credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
-    projects:["sbt-republish"]
+  options: {
+    deploy: [
+      {
+        uri="http://private-repo.typesafe.com/typesafe/ide-2.11",
+        credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
+        projects:["sbt-republish"]
+      }
+    ]
   }
-  ]
 }


### PR DESCRIPTION
The updated scripts now requires dbuild v0.6.3

Fixes #1

@jsuereth I took a stab at it.
