### PR TITLE
Parameterize dbuilds on Scala version.

### DIFF
--- a/bin/dbuild
+++ b/bin/dbuild
@@ -3,6 +3,7 @@
 SCRIPT_DIR=$(dirname $0)
 
 java \
+  -Dmaven.local.repo=$LOCAL_M2_REPO \
   -Dsbt.boot.properties=$SCRIPT_DIR/dbuild.properties \
   -jar $SCRIPT_DIR/sbt-launch.jar \
   $@

--- a/bin/dbuild.properties
+++ b/bin/dbuild.properties
@@ -13,6 +13,7 @@
 [repositories]
   local
   maven-central
+  m2repo: file://${maven.local.repo-${user.dir}/m2repo}
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
   java-annoying-cla-shtuff: http://download.java.net/maven/2/
   typesafe-releases: http://typesafe.artifactoryonline.com/typesafe/releases

--- a/sbt-on-2.10.x
+++ b/sbt-on-2.10.x
@@ -1,26 +1,32 @@
+// External variables (expected to be set as environment variables before calling dbuild)
+// NOTE: There are no defaults.
+//
+// SCALA_VERSION
+// PUBLISH_REPO
+
 {
   build: {
     "projects":[
       {
         name:  "scala-lib",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;2.10.3-SNAPSHOT"
-        set-version: "2.10.3-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-library;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;2.10.3-SNAPSHOT"
-        set-version: "2.10.3-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-compiler;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;2.10.3-SNAPSHOT"
-        set-version: "2.10.3-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-actors;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;2.10.3-SNAPSHOT"
-        set-version: "2.10.3-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-reflect;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:   "scalacheck",
         system: "ivy",
@@ -43,7 +49,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-2.10.3-SNAPSHOT-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-on-"${SCALA_VERSION}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git"
@@ -55,6 +61,7 @@
     deploy: [
       {
         uri="http://private-repo.typesafe.com/typesafe/ide-2.10",
+        uri=${?PUBLISH_REPO},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -1,36 +1,47 @@
+// External variables (expected to be set as environment variables before calling dbuild)
+// NOTE: There are no defaults.
+//
+// SCALA_VERSION
+// PUBLISH_REPO
+//
+// TODO:
+//   SCALA_BINARY_VERSION
+//   SCALA_XML_VERSION
+//   SCALA_COMBINATORS_VERSION
+
 {
   build: {
     "projects":[
       {
         name:  "scala-lib",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;2.11.0-SNAPSHOT"
-       set-version: "2.11.0-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-library;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;2.11.0-SNAPSHOT"
-        set-version: "2.11.0-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-compiler;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;2.11.0-SNAPSHOT"
-       set-version: "2.11.0-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-actors;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;2.11.0-SNAPSHOT"
-        set-version: "2.11.0-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-reflect;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-xml",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-xml;2.11.0-M4"
-        set-version: "2.11.0-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-xml;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:  "scala-parser-combinators",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-parser-combinators;2.11.0-M4"
-        set-version: "2.11.0-SNAPSHOT"
+        uri:    "ivy:org.scala-lang#scala-parser-combinators;"${SCALA_VERSION}
+        set-version: ${SCALA_VERSION}
       }, {
         name:   "sbinary",
         uri:    "git://github.com/harrah/sbinary.git"
@@ -53,7 +64,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-2.11.0-SNAPSHOT-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-on-"${SCALA_VERSION}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git"
@@ -65,6 +76,7 @@
     deploy: [
       {
         uri="http://private-repo.typesafe.com/typesafe/ide-2.11",
+        uri=${?PUBLISH_REPO},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }


### PR DESCRIPTION
This allows us to use the same configuration for nightlies and PR validation.

@jsuereth, can you please confirm this still works for q-team nightlies? you'll need to export at least `SCALA_VERSION` when calling dbuild.
