### PR TITLE
Move `m2repo` below maven-central, so Maven artifacts are found.

### DIFF
--- a/bin/dbuild.properties
+++ b/bin/dbuild.properties
@@ -12,8 +12,8 @@
 
 [repositories]
   local
-  m2repo: file://${maven.local.repo-${user.dir}/m2repo}
   maven-central
+  m2repo: file://${maven.local.repo-${user.dir}/m2repo}
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
   java-annoying-cla-shtuff: http://download.java.net/maven/2/
   typesafe-releases: http://typesafe.artifactoryonline.com/typesafe/releases


### PR DESCRIPTION
It seems Ivy can't handle the local maven repository if it's incomplete.
