### PR TITLE
Fixes for scala 2.11 modularization

### DIFF
--- a/bin/dbuild.properties
+++ b/bin/dbuild.properties
@@ -5,7 +5,7 @@
 [app]
   org: com.typesafe.dbuild
   name: d-build
-  version: 0.6.4-josh-hack-1
+  version: 0.6.4-josh-hack-3
   class: distributed.build.SbtBuildMain
   cross-versioned: true
   components: xsbti

--- a/bin/drepo.properties
+++ b/bin/drepo.properties
@@ -5,7 +5,7 @@
 [app]
   org: com.typesafe.dbuild
   name: d-repo
-  version: 0.6.4
+  version: 0.6.4-josh-hack-3
   class: distributed.repo.core.SbtRepoMain
   cross-versioned: true
   components: xsbti

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -11,34 +11,38 @@
   build: {
     "projects":[
       {
-        name:  "scala-lib",
+        name:  "scala-xml",
         system: "ivy",
-        set-version: ${globals.scala-version}
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
+        uri:    "ivy:org.scala-lang.modules#scala-xml_2.11.0-M4;1.0-RC3"
+        set-version: "1.0-RC3",
+        extra: {
+          excludes: [{
+            organization: "org.scala-lang",
+            name: "scala-library"
+          }]
+        }
       }, {
-        name:  "scala-compiler",
+        name:  "scala-parser-combinators",
         system: "ivy",
-        set-version: ${globals.scala-version}
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
+        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_2.11.0-M4;1.0-RC1"
+        set-version: "1.0-RC1",
+        extra: {
+          excludes: [{
+            organization: "org.scala-lang",
+            name: "scala-library"
+          }]
+        }
       }, {
-        name:  "scala-actors",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
-        set-version: ${globals.scala-version}
-      }, {
-        name:  "scala-reflect",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
+        name:  "scala",
+        system: "scala", 
+        uri:    "git://github.com/jsuereth/scala.git#wip/modularize-xml-parsres", //adriaanm:modularize-xml-parsers
         set-version: ${globals.scala-version}
       }, {
         name:   "sbinary",
         uri:    "git://github.com/harrah/sbinary.git#2.11"
         extra: {
           projects: ["core"],
-          run-tests: false, // Sbinary has some invalid case classes currently.
-          commands: [
-            "set (libraryDependencies in core) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }"
-          ]  
+          run-tests: false // Sbinary has some invalid case classes currently.
         }
       }, {
         name:   "sbt",
@@ -50,11 +54,7 @@
                      "compiler-integration","incremental-compiler","compile","launcher-interface"
                     ],
           run-tests: false,
-          commands: [ "set every Util.includeTestDependencies := false", // Without this, we have to build specs2
-                      "set (libraryDependencies in cacheSub           ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }",
-                      "set (libraryDependencies in compilePersistSub  ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }",
-                      "set (libraryDependencies in mainSub            ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }",
-                      "set (libraryDependencies in processSub         ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }"
+          commands: [ "set every Util.includeTestDependencies := false" // Without this, we have to build specs2
                     ]
         }
       }, {

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -29,16 +29,6 @@
         uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
         set-version: ${globals.scala-version}
       }, {
-        name:  "scala-xml",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-xml;2.11.0-M4"
-        set-version: ${globals.scala-version}
-      }, {
-        name:  "scala-parser-combinators",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-parser-combinators;2.11.0-M4"
-        set-version: ${globals.scala-version}
-      }, {
         name:   "sbinary",
         uri:    "git://github.com/harrah/sbinary.git"
         extra: {

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -30,14 +30,14 @@
         set-version: ${globals.scala-version}
       }, {
         name:   "sbinary",
-        uri:    "git://github.com/harrah/sbinary.git"
+        uri:    "git://github.com/harrah/sbinary.git#2.11"
         extra: {
           projects: ["core"],
           run-tests: false // Sbinary has some invalid case classes currently.
         }
       }, {
         name:   "sbt",
-        uri:    "git://github.com/sbt/sbt.git#0.13.0"
+        uri:    "git://github.com/sbt/sbt.git#0.13-2.11"
         extra: {
           projects: ["compiler-interface",
                      "classpath","logging","io","control","classfile",

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -3,6 +3,8 @@
   globals: {
     scala-version: "2.11.0-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
+    scala-binary-version: "2.11.0-M4"
+    scala-binary-version: ${?SCALA_BINARY_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.11"
     publish-repo: ${?PUBLISH_REPO}
   }
@@ -33,7 +35,10 @@
         uri:    "git://github.com/harrah/sbinary.git#2.11"
         extra: {
           projects: ["core"],
-          run-tests: false // Sbinary has some invalid case classes currently.
+          run-tests: false, // Sbinary has some invalid case classes currently.
+          commands: [
+            "set (libraryDependencies in core) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }"
+          ]  
         }
       }, {
         name:   "sbt",
@@ -45,7 +50,12 @@
                      "compiler-integration","incremental-compiler","compile","launcher-interface"
                     ],
           run-tests: false,
-          commands: [ "set every Util.includeTestDependencies := false" ] // Without this, we have to build specs2
+          commands: [ "set every Util.includeTestDependencies := false", // Without this, we have to build specs2
+                      "set (libraryDependencies in cacheSub           ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }",
+                      "set (libraryDependencies in compilePersistSub  ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }",
+                      "set (libraryDependencies in mainSub            ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }",
+                      "set (libraryDependencies in processSub         ) ~= { ld => ld map { case dep if (dep.organization == \"org.scala-lang.modules\") => dep cross CrossVersion.fullMapped(_ => \""${globals.scala-binary-version}"\") case dep => dep } }"
+                    ]
         }
       }, {
         name:   "sbt-republish",

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -14,28 +14,31 @@
         name:  "scala-xml",
         system: "ivy",
         uri:    "ivy:org.scala-lang.modules#scala-xml_2.11.0-M4;1.0-RC3"
-        set-version: "1.0-RC3",
-        extra: {
-          excludes: [{
-            organization: "org.scala-lang",
-            name: "scala-library"
-          }]
-        }
+        set-version: "1.0-RC3"
       }, {
         name:  "scala-parser-combinators",
         system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_2.11.0-M4;1.0-RC1"
-        set-version: "1.0-RC1",
-        extra: {
-          excludes: [{
-            organization: "org.scala-lang",
-            name: "scala-library"
-          }]
-        }
+        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_2.11.0-M4;1.0-RC1",
+        set-version: "1.0-RC1"
       }, {
-        name:  "scala",
-        system: "scala", 
-        uri:    "git://github.com/jsuereth/scala.git#wip/modularize-xml-parsres", //adriaanm:modularize-xml-parsers
+        name:  "scala-lib",
+        system: "ivy",
+        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
+      }, {
+        name:  "scala-compiler",
+        system: "ivy",
+        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
+      }, {
+        name:  "scala-actors",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
+        set-version: ${globals.scala-version}
+      }, {
+        name:  "scala-reflect",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
         set-version: ${globals.scala-version}
       }, {
         name:   "sbinary",


### PR DESCRIPTION
Note: The build actually needs to change for the latest Scala 2.11 branch (once modularization is fixed).

This makes use of the fixes here:

https://github.com/typesafehub/distributed-build/pull/47

And fixes our build so this can get merged:

https://github.com/scala/scala/pull/2855

Assuming this is merged first:

https://github.com/adriaanm/scala/pull/7

In particular, this uses another temporary dbuild release (pending review of improvements) and a branch for scala which includes the dbuild-meta.json fixes.   Those will have to point back at scala/scala.git#master before merging.

Also, we removed resolving Scala via ivy for now.   There is no way to construct a complete scala-home in dbuild's sbt rewriting.   It should be innocuous to rebuild scala here, as binary compatibilty should remain in place for the potential few hour difference between build.

Also, if this is going to be used by PR validation, then we'll have to try out the partial support for PR references, see:

https://github.com/typesafehub/distributed-build/issues/35

Reivew by @dragos and @adriaanm 
