### PR TITLE
Bump to Scala 2.10.3-RC3

### DIFF
--- a/sbt-on-2.10.3
+++ b/sbt-on-2.10.3
@@ -1,7 +1,7 @@
 {
   // Variables that may be external.  We have the defaults here.
   globals: {
-    scala-version: "2.10.3-RC2"
+    scala-version: "2.10.3-RC3"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
     publish-repo: ${?PUBLISH_REPO}


### PR DESCRIPTION
We needed an RC3. @jsuereth, can we please have corresponding a release this project to enable the IDE build?

I'll comment here when I've release the Scala artifacts to Maven, should be within 2 hours.
