### PR TITLE
Fix current nightlies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,19 @@ This will create a bunch of files, and a repository in:
 
 which contains all artifacts.
 
-
 *Note: Only runs on linux/macosx*
+
+## Layout of builds.
+
+The builds inside of this project are split into two styles:
+
+* `sbt-on-<scala-version>`:
+   These builds are against *stable* sbt/zinc branches and *unstable* scala artifacts (`-SNAPSHOT`).  These are built primarily for
+   integration with the IDE and the scala pr-validator.  These builds must always be stable, or we start holding up
+   both the Scala and the Scala IDE projects.
+* `sbt-all-nightly-on-<scala-version>`:
+   These builds are against *unstable* sbt/zinc branches and *unstable* scala artifacts (`-SNAPSHOT`).  These are built primarily for
+   the sbt/zinc teams to ensure that their integration is up-to-snuff leading to a release.
+
+
+*TODO:  We should add a new sbt-nightly-on-<stable-scala> integration build which ensures we can build sbt/zinc against stable scala.*

--- a/bin/dbuild.properties
+++ b/bin/dbuild.properties
@@ -5,7 +5,7 @@
 [app]
   org: com.typesafe.dbuild
   name: d-build
-  version: 0.6.4-josh-hack-3
+  version: 0.6.5
   class: distributed.build.SbtBuildMain
   cross-versioned: true
   components: xsbti

--- a/sbt-all-nightly-on-2.10.x
+++ b/sbt-all-nightly-on-2.10.x
@@ -1,12 +1,12 @@
 {
   // Variables that may be external.  We have the defaults here.
   globals: {
-    scala-version: "2.10.2"
+    scala-version: "2.10.4-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
     publish-repo: ${?PUBLISH_REPO}
   }
-   build: {
+  build: {
     "projects":[
       {
         name:  "scala-lib",
@@ -34,19 +34,18 @@
         uri:    "ivy:org.scalacheck#scalacheck_2.10;1.10.1"
       }, {
         name:   "sbinary",
-        uri:    "git://github.com/harrah/sbinary.git"
+        uri:    "git://github.com/harrah/sbinary.git#v0.4.2"
         extra: { projects: ["core"] }
       }, {
         name:   "sbt",
-        uri:    "git://github.com/sbt/sbt.git#0.13.0"
+        uri:    "git://github.com/sbt/sbt.git#v0.13"
         extra: {
           projects: ["compiler-interface",
                      "classpath","logging","io","control","classfile",
                      "process","relation","interface","persist","api",
                      "compiler-integration","incremental-compiler","compile","launcher-interface"
                     ],
-          run-tests: false,
-          sbt-version: "0.13.0"
+          run-tests: false
         }
       }, {
         name:   "sbt-republish",
@@ -54,7 +53,7 @@
         set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
-        uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
+        uri:    "https://github.com/typesafehub/zinc.git"
       }
     ],
     options:{cross-version:standard},
@@ -72,7 +71,7 @@
         projects: "."
         send.to: "qbranch@typesafe.com"
         when: bad
-      },{
+      },{ 
         projects: "."
         kind: console
         when: always

--- a/sbt-all-nightly-on-2.10.x
+++ b/sbt-all-nightly-on-2.10.x
@@ -1,6 +1,6 @@
 {
   // Variables that may be external.  We have the defaults here.
-  globals: {
+  vars: {
     scala-version: "2.10.4-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
@@ -11,23 +11,23 @@
       {
         name:  "scala-lib",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:   "scalacheck",
         system: "ivy",
@@ -38,8 +38,9 @@
         extra: { projects: ["core"] }
       }, {
         name:   "sbt",
-        uri:    "git://github.com/sbt/sbt.git#v0.13"
+        uri:    "git://github.com/sbt/sbt.git#0.13"
         extra: {
+          sbt-version: "0.13.0",
           projects: ["compiler-interface",
                      "classpath","logging","io","control","classfile",
                      "process","relation","interface","persist","api",
@@ -50,7 +51,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-master-on-"${vars.scala-version}"-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git"
@@ -61,7 +62,7 @@
   options: {
     deploy: [
       {
-        uri=${?globals.publish-repo},
+        uri=${?vars.publish-repo},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }

--- a/sbt-all-nightly-on-2.11.x
+++ b/sbt-all-nightly-on-2.11.x
@@ -1,23 +1,39 @@
 {
   // Variables that may be external.  We have the defaults here.
   globals: {
-    scala-version: "2.10.2"
+    scala-version: "2.11.0-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
-    publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
+    scala-binary-version: "2.11.0-M5"
+    scala-binary-version: ${?SCALA_BINARY_VERSION}
+    parser-combinator-version: "1.0.0-RC3"
+    parser-combinator-version: ${?SCALA_PARSER_COMBINATOR_VERSION}
+    xml-version: "1.0.0-RC5"
+    xml-version: ${?SCALA_XML_VERSION}
+    publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.11"
     publish-repo: ${?PUBLISH_REPO}
   }
-   build: {
+  build: {
     "projects":[
       {
+        name:  "scala-xml",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang.modules#scala-xml_"${globals.scala-binary-version}";"${globals.xml-version}
+        set-version: "1.0-RC3"
+      }, {
+        name:  "scala-parser-combinators",
+        system: "ivy",
+        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${globals.scala-binary-version}";"${globals.parser-combinator-version},
+        set-version: "1.0-RC1"
+      }, {
         name:  "scala-lib",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
         set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
         set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
       }, {
         name:  "scala-actors",
         system: "ivy",
@@ -29,16 +45,15 @@
         uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
         set-version: ${globals.scala-version}
       }, {
-        name:   "scalacheck",
-        system: "ivy",
-        uri:    "ivy:org.scalacheck#scalacheck_2.10;1.10.1"
-      }, {
         name:   "sbinary",
-        uri:    "git://github.com/harrah/sbinary.git"
-        extra: { projects: ["core"] }
+        uri:    "git://github.com/harrah/sbinary.git#2.11"
+        extra: {
+          projects: ["core"],
+          run-tests: false // Sbinary has some invalid case classes currently.
+        }
       }, {
         name:   "sbt",
-        uri:    "git://github.com/sbt/sbt.git#0.13.0"
+        uri:    "git://github.com/sbt/sbt.git#0.13"
         extra: {
           projects: ["compiler-interface",
                      "classpath","logging","io","control","classfile",
@@ -46,7 +61,8 @@
                      "compiler-integration","incremental-compiler","compile","launcher-interface"
                     ],
           run-tests: false,
-          sbt-version: "0.13.0"
+          commands: [ "set every Util.includeTestDependencies := false" // Without this, we have to build specs2
+                    ]
         }
       }, {
         name:   "sbt-republish",
@@ -54,7 +70,7 @@
         set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
-        uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
+        uri:    "https://github.com/typesafehub/zinc.git"
       }
     ],
     options:{cross-version:standard},
@@ -72,7 +88,7 @@
         projects: "."
         send.to: "qbranch@typesafe.com"
         when: bad
-      },{
+      },{ 
         projects: "."
         kind: console
         when: always

--- a/sbt-all-nightly-on-2.11.x
+++ b/sbt-all-nightly-on-2.11.x
@@ -1,6 +1,6 @@
 {
   // Variables that may be external.  We have the defaults here.
-  globals: {
+  vars: {
     scala-version: "2.11.0-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
     scala-binary-version: "2.11.0-M5"
@@ -17,33 +17,33 @@
       {
         name:  "scala-xml",
         system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-xml_"${globals.scala-binary-version}";"${globals.xml-version}
+        uri:    "ivy:org.scala-lang.modules#scala-xml_"${vars.scala-binary-version}";"${vars.xml-version}
         set-version: "1.0-RC3"
       }, {
         name:  "scala-parser-combinators",
         system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${globals.scala-binary-version}";"${globals.parser-combinator-version},
+        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${vars.scala-binary-version}";"${vars.parser-combinator-version},
         set-version: "1.0-RC1"
       }, {
         name:  "scala-lib",
         system: "ivy",
-        set-version: ${globals.scala-version}
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
+        set-version: ${vars.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        set-version: ${globals.scala-version}
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
+        set-version: ${vars.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:   "sbinary",
         uri:    "git://github.com/harrah/sbinary.git#2.11"
@@ -54,6 +54,7 @@
       }, {
         name:   "sbt",
         uri:    "git://github.com/sbt/sbt.git#0.13"
+        sbt-version: "0.13.0",
         extra: {
           projects: ["compiler-interface",
                      "classpath","logging","io","control","classfile",
@@ -67,7 +68,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-master-on-"${vars.scala-version}"-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git"
@@ -78,7 +79,7 @@
   options: {
     deploy: [
       {
-        uri=${?globals.publish-repo},
+        uri=${?vars.publish-repo},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }

--- a/sbt-on-2.10.2
+++ b/sbt-on-2.10.2
@@ -1,6 +1,6 @@
 {
   // Variables that may be external.  We have the defaults here.
-  globals: {
+  vars: {
     scala-version: "2.10.2"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
@@ -11,23 +11,23 @@
       {
         name:  "scala-lib",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:   "scalacheck",
         system: "ivy",
@@ -51,7 +51,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-on-"${vars.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
@@ -62,7 +62,7 @@
   options: {
     deploy: [
       {
-        uri=${?globals.publish-repo},
+        uri=${?vars.publish-repo},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }

--- a/sbt-on-2.10.3
+++ b/sbt-on-2.10.3
@@ -1,6 +1,6 @@
 {
   // Variables that may be external.  We have the defaults here.
-  globals: {
+  vars: {
     scala-version: "2.10.3"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
@@ -11,23 +11,23 @@
       {
         name:  "scala-lib",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:   "scalacheck",
         system: "ivy",
@@ -51,7 +51,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-on-"${vars.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
@@ -62,7 +62,7 @@
   options: {
     deploy: [
       {
-        uri=${?globals.publish-repo},
+        uri=${?vars.publish-repo},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }

--- a/sbt-on-2.10.3
+++ b/sbt-on-2.10.3
@@ -54,7 +54,7 @@
         set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
-        uri:    "https://github.com/typesafehub/zinc.git"
+        uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
       }
     ],
     options:{cross-version:standard},

--- a/sbt-on-2.10.x
+++ b/sbt-on-2.10.x
@@ -1,6 +1,6 @@
 {
   // Variables that may be external.  We have the defaults here.
-  globals: {
+  vars: {
     scala-version: "2.10.4-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
@@ -11,23 +11,23 @@
       {
         name:  "scala-lib",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:   "scalacheck",
         system: "ivy",
@@ -50,7 +50,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-on-"${vars.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
@@ -61,7 +61,7 @@
   options: {
     deploy: [
       {
-        uri=${?globals.publish-repo},
+        uri=${?vars.publish-repo},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }

--- a/sbt-on-2.10.x
+++ b/sbt-on-2.10.x
@@ -53,7 +53,7 @@
         set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
-        uri:    "https://github.com/typesafehub/zinc.git"
+        uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
       }
     ],
     options:{cross-version:standard},

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -1,6 +1,6 @@
 {
   // Variables that may be external.  We have the defaults here.
-  globals: {
+  vars: {
     scala-version: "2.11.0-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
     scala-binary-version: "2.11.0-M5"
@@ -17,33 +17,33 @@
       {
         name:  "scala-xml",
         system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-xml_"${globals.scala-binary-version}";"${globals.xml-version}
+        uri:    "ivy:org.scala-lang.modules#scala-xml_"${vars.scala-binary-version}";"${vars.xml-version}
         set-version: "1.0-RC3"
       }, {
         name:  "scala-parser-combinators",
         system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${globals.scala-binary-version}";"${globals.parser-combinator-version},
+        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${vars.scala-binary-version}";"${vars.parser-combinator-version},
         set-version: "1.0-RC1"
       }, {
         name:  "scala-lib",
         system: "ivy",
-        set-version: ${globals.scala-version}
-        uri:    "ivy:org.scala-lang#scala-library;"${globals.scala-version}
+        set-version: ${vars.scala-version}
+        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
       }, {
         name:  "scala-compiler",
         system: "ivy",
-        set-version: ${globals.scala-version}
-        uri:    "ivy:org.scala-lang#scala-compiler;"${globals.scala-version}
+        set-version: ${vars.scala-version}
+        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
       }, {
         name:  "scala-actors",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:  "scala-reflect",
         system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${globals.scala-version}
-        set-version: ${globals.scala-version}
+        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
+        set-version: ${vars.scala-version}
       }, {
         name:   "sbinary",
         uri:    "git://github.com/harrah/sbinary.git#2.11"
@@ -67,7 +67,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-on-"${vars.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
@@ -78,7 +78,7 @@
   options: {
     deploy: [
       {
-        uri=${?globals.publish-repo},
+        uri=${?vars.publish-repo},
         credentials="/home/jenkinsdbuild/dbuild-josh-credentials.properties",
         projects:["sbt-republish"]
       }

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -70,7 +70,7 @@
         set-version: "0.13.0-on-"${globals.scala-version}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
-        uri:    "https://github.com/typesafehub/zinc.git"
+        uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
       }
     ],
     options:{cross-version:standard},


### PR DESCRIPTION
- Keep zinc + sbt branches synched.  We can't use stable sbt + unstable zinc for IDE/Scala builds.  Migrate to both stable.
- Create new build files for all unstable branches (to catch issues between inc. compiler changes + zinc
- Upgrade to dbuild 0.6.5.

Review by @harrah / @cunei 

cc> @retronym @adriaanm @gkossakowski @dragos - and sorry for the breakage.
