### PR TITLE
Use dbuild 0.7.0. Read versions.properties.

### DIFF
--- a/bin/dbuild.properties
+++ b/bin/dbuild.properties
@@ -5,7 +5,7 @@
 [app]
   org: com.typesafe.dbuild
   name: d-build
-  version: 0.6.6-test-fd5
+  version: 0.7.0
   class: distributed.build.SbtBuildMain
   cross-versioned: true
   components: xsbti

--- a/bin/dbuild.properties
+++ b/bin/dbuild.properties
@@ -5,7 +5,7 @@
 [app]
   org: com.typesafe.dbuild
   name: d-build
-  version: 0.6.5
+  version: 0.6.6-test-fd5
   class: distributed.build.SbtBuildMain
   cross-versioned: true
   components: xsbti

--- a/bin/drepo.properties
+++ b/bin/drepo.properties
@@ -5,7 +5,7 @@
 [app]
   org: com.typesafe.dbuild
   name: d-repo
-  version: 0.6.6-test-fd5
+  version: 0.7.0
   class: distributed.repo.core.SbtRepoMain
   cross-versioned: true
   components: xsbti

--- a/bin/drepo.properties
+++ b/bin/drepo.properties
@@ -5,7 +5,7 @@
 [app]
   org: com.typesafe.dbuild
   name: d-repo
-  version: 0.6.4-josh-hack-3
+  version: 0.6.6-test-fd5
   class: distributed.repo.core.SbtRepoMain
   cross-versioned: true
   components: xsbti

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -1,45 +1,61 @@
 {
+  properties: "file://"${PWD}"/versions.properties"
   // Variables that may be external.  We have the defaults here.
   vars: {
-    scala-version: "2.11.0-SNAPSHOT"
-    scala-version: ${?SCALA_VERSION}
-    scala-binary-version: "2.11.0-M5"
-    scala-binary-version: ${?SCALA_BINARY_VERSION}
-    parser-combinator-version: "1.0.0-RC3"
-    parser-combinator-version: ${?SCALA_PARSER_COMBINATOR_VERSION}
-    xml-version: "1.0.0-RC5"
-    xml-version: ${?SCALA_XML_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.11"
     publish-repo: ${?PUBLISH_REPO}
   }
   build: {
     "projects":[
       {
-        name:  "scala-xml",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-xml_"${vars.scala-binary-version}";"${vars.xml-version}
-        set-version: "1.0-RC3"
-      }, {
-        name:  "scala-parser-combinators",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${vars.scala-binary-version}";"${vars.parser-combinator-version},
-        set-version: "1.0-RC1"
-      }, {
-        name:  "scala-lib",
-        system: "ivy",
-        set-version: ${vars.scala-version}
-        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
-      }, {
-        name:  "scala-compiler",
-        system: "ivy",
-        set-version: ${vars.scala-version}
-        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
-      }, {
-        name:  "scala-reflect",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
-        set-version: ${vars.scala-version}
-      }, {
+        system: assemble
+        name:   scala2
+        extra.parts.options: {
+          cross-version: standard
+          sbt-version: "0.13.0"
+        }
+        extra.parts.projects: [
+          {
+            name:  "scala-lib",
+            system: "ivy",
+            set-version: ${vars.maven.version.number}
+            uri:    "ivy:org.scala-lang#scala-library;"${vars.maven.version.number}
+          }, {
+            name:  "scala-reflect",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang#scala-reflect;"${vars.maven.version.number}
+            set-version: ${vars.maven.version.number}
+          }, {
+            name:  "scala-compiler",
+            system: "ivy",
+            set-version: ${vars.maven.version.number}
+            uri:    "ivy:org.scala-lang#scala-compiler;"${vars.maven.version.number}
+          },
+          // {
+          //   name:  "scala-compiler-doc",
+          //   system: "ivy",
+          //   set-version: ${vars.scala-compiler-doc.version.number}
+          //   uri:    "ivy:org.scala-lang.modules#scala-compiler-doc_"${vars.scala.binary.version}";"${vars.scala-compiler-doc.version.number}
+          // }, {
+          //   name:  "scala-compiler-interactive",
+          //   system: "ivy",
+          //   set-version: ${vars.scala-compiler-interactive.version.number}
+          //   uri:    "ivy:org.scala-lang.modules#scala-compiler-interactive_"${vars.scala.binary.version}";"${vars.scala-compiler-interactive.version.number}
+          // },
+          {
+            name:  "scala-xml",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang.modules#scala-xml_"${vars.scala.binary.version}";"${vars.scala-xml.version.number}
+            set-version: "1.0-RC3" // required by sbinary?
+          }, {
+            name:  "scala-parser-combinators",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${vars.scala.binary.version}";"${vars.scala-parser-combinators.version.number},
+            set-version: "1.0-RC1" // required by sbinary?
+          }
+        ]
+      },
+      {
         name:   "sbinary",
         uri:    "git://github.com/harrah/sbinary.git#2.11"
         extra: {
@@ -62,7 +78,7 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${vars.scala-version}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0-on-"${vars.maven.version.number}"-for-IDE-SNAPSHOT"
       }, {
         name:   "zinc",
         uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"

--- a/versions.properties
+++ b/versions.properties
@@ -1,0 +1,6 @@
+maven.version.number=2.11.0-SNAPSHOT
+
+scala.binary.version=2.11.0-M6
+partest.version.number=1.0.0-RC7
+scala-xml.version.number=1.0.0-RC6
+scala-parser-combinators.version.number=1.0.0-RC4


### PR DESCRIPTION
Uses the new 'assemble' build system.

Tested by: https://scala-webapps.epfl.ch/jenkins/job/pr-scala-integrate-ide/3922/consoleText

As witnessed by:

```
From git://github.com/adriaanm/sbt-builds-for-ide
 + 66710ff...35afb80 master     -> remote03/master  (forced update)
```

review by @jsuereth, /cc @cunei, @skyluc
