### PR TITLE
Align sbt build for IDE and nightly build.

### DIFF
--- a/sbt-all-nightly-on-2.11.x
+++ b/sbt-all-nightly-on-2.11.x
@@ -1,77 +1,83 @@
 {
+  properties: "file://"${PWD}"/versions.properties"
   // Variables that may be external.  We have the defaults here.
   vars: {
-    scala-version: "2.11.0-SNAPSHOT"
-    scala-version: ${?SCALA_VERSION}
-    scala-binary-version: "2.11.0-M5"
-    scala-binary-version: ${?SCALA_BINARY_VERSION}
-    parser-combinator-version: "1.0.0-RC3"
-    parser-combinator-version: ${?SCALA_PARSER_COMBINATOR_VERSION}
-    xml-version: "1.0.0-RC5"
-    xml-version: ${?SCALA_XML_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.11"
     publish-repo: ${?PUBLISH_REPO}
+    sbt.version.suffix: ""
+    sbt.branch.prefix: "-master"
+    zinc.gitref: "master"
   }
   build: {
     "projects":[
       {
-        name:  "scala-xml",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-xml_"${vars.scala-binary-version}";"${vars.xml-version}
-        set-version: "1.0-RC3"
-      }, {
-        name:  "scala-parser-combinators",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${vars.scala-binary-version}";"${vars.parser-combinator-version},
-        set-version: "1.0-RC1"
-      }, {
-        name:  "scala-lib",
-        system: "ivy",
-        set-version: ${vars.scala-version}
-        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
-      }, {
-        name:  "scala-compiler",
-        system: "ivy",
-        set-version: ${vars.scala-version}
-        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
-      }, {
-        name:  "scala-actors",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
-        set-version: ${vars.scala-version}
-      }, {
-        name:  "scala-reflect",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
-        set-version: ${vars.scala-version}
-      }, {
-        name:   "sbinary",
-        uri:    "git://github.com/harrah/sbinary.git#2.11"
-        extra: {
-          projects: ["core"],
-          run-tests: false // Sbinary has some invalid case classes currently.
+        system: assemble
+        name:   scala2
+        deps.ignore: "org.scalacheck#scalacheck"
+        extra.parts.options: {
+          cross-version: standard
+          sbt-version: "0.13.0"
         }
+        extra.parts.projects: [
+          {
+            name:  "scala-lib",
+            system: "ivy",
+            set-version: ${vars.maven.version.number}
+            uri:    "ivy:org.scala-lang#scala-library;"${vars.maven.version.number}
+          }, {
+            name:  "scala-reflect",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang#scala-reflect;"${vars.maven.version.number}
+            set-version: ${vars.maven.version.number}
+          }, {
+            name:  "scala-compiler",
+            system: "ivy",
+            set-version: ${vars.maven.version.number}
+            uri:    "ivy:org.scala-lang#scala-compiler;"${vars.maven.version.number}
+          },
+          {
+            name:  "scala-xml",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang.modules#scala-xml_"${vars.scala.binary.version}";"${vars.scala-xml.version.number}
+            set-version: "1.0-RC3" // required by sbinary?
+          }, {
+            name:  "scala-parser-combinators",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${vars.scala.binary.version}";"${vars.scala-parser-combinators.version.number},
+            set-version: "1.0-RC1" // required by sbinary?
+          }
+        ]
+      },
+      {
+        name: scalacheck
+        extra.sbt-version: "0.13.0",
+        uri: "https://github.com/rickynils/scalacheck.git#1.11.1"
+      },
+      {
+        name:   "sbinary",
+        extra.sbt-version: "0.13.0",
+        uri:    "git://github.com/harrah/sbinary.git#2.11"
       }, {
         name:   "sbt",
         uri:    "git://github.com/sbt/sbt.git#0.13"
         extra: {
+          sbt-version: "0.13.0",
           projects: ["compiler-interface",
                      "classpath","logging","io","control","classfile",
                      "process","relation","interface","persist","api",
                      "compiler-integration","incremental-compiler","compile","launcher-interface"
                     ],
           run-tests: false,
-          sbt-version: "0.13.0",
           commands: [ "set every Util.includeTestDependencies := false" // Without this, we have to build specs2
                     ]
         }
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-master-on-"${vars.scala-version}"-SNAPSHOT"
+        set-version: "0.13.0"${vars.sbt.branch.prefix}"-on-"${vars.maven.version.number}${vars.sbt.version.suffix}"-SNAPSHOT"
       }, {
         name:   "zinc",
-        uri:    "https://github.com/typesafehub/zinc.git"
+        uri:    "https://github.com/typesafehub/zinc.git#"${vars.zinc.gitref}
       }
     ],
     options:{cross-version:standard},

--- a/sbt-on-2.11.x
+++ b/sbt-on-2.11.x
@@ -4,12 +4,16 @@
   vars: {
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.11"
     publish-repo: ${?PUBLISH_REPO}
+    sbt.version.suffix: "-for-IDE"
+    sbt.branch.prefix: ""
+    zinc.gitref: "v0.3.0"
   }
   build: {
     "projects":[
       {
         system: assemble
         name:   scala2
+        deps.ignore: "org.scalacheck#scalacheck"
         extra.parts.options: {
           cross-version: standard
           sbt-version: "0.13.0"
@@ -31,17 +35,6 @@
             set-version: ${vars.maven.version.number}
             uri:    "ivy:org.scala-lang#scala-compiler;"${vars.maven.version.number}
           },
-          // {
-          //   name:  "scala-compiler-doc",
-          //   system: "ivy",
-          //   set-version: ${vars.scala-compiler-doc.version.number}
-          //   uri:    "ivy:org.scala-lang.modules#scala-compiler-doc_"${vars.scala.binary.version}";"${vars.scala-compiler-doc.version.number}
-          // }, {
-          //   name:  "scala-compiler-interactive",
-          //   system: "ivy",
-          //   set-version: ${vars.scala-compiler-interactive.version.number}
-          //   uri:    "ivy:org.scala-lang.modules#scala-compiler-interactive_"${vars.scala.binary.version}";"${vars.scala-compiler-interactive.version.number}
-          // },
           {
             name:  "scala-xml",
             system: "ivy",
@@ -56,17 +49,19 @@
         ]
       },
       {
+        name: scalacheck
+        extra.sbt-version: "0.13.0",
+        uri: "https://github.com/rickynils/scalacheck.git#1.11.1"
+      },
+      {
         name:   "sbinary",
+        extra.sbt-version: "0.13.0",
         uri:    "git://github.com/harrah/sbinary.git#2.11"
-        extra: {
-          projects: ["core"],
-          run-tests: false // Sbinary has some invalid case classes currently.
-          sbt-version: "0.13.0"
-        }
       }, {
         name:   "sbt",
-        uri:    "git://github.com/sbt/sbt.git#0.13-2.11"
+        uri:    "git://github.com/sbt/sbt.git#0.13"
         extra: {
+          sbt-version: "0.13.0",
           projects: ["compiler-interface",
                      "classpath","logging","io","control","classfile",
                      "process","relation","interface","persist","api",
@@ -79,10 +74,10 @@
       }, {
         name:   "sbt-republish",
         uri:    "http://github.com/typesafehub/sbt-republish.git#master",
-        set-version: "0.13.0-on-"${vars.maven.version.number}"-for-IDE-SNAPSHOT"
+        set-version: "0.13.0"${vars.sbt.branch.prefix}"-on-"${vars.maven.version.number}${vars.sbt.version.suffix}"-SNAPSHOT"
       }, {
         name:   "zinc",
-        uri:    "https://github.com/typesafehub/zinc.git#v0.3.0"
+        uri:    "https://github.com/typesafehub/zinc.git#"${vars.zinc.gitref}
       }
     ],
     options:{cross-version:standard},
@@ -115,3 +110,16 @@
     }
   }
 }
+
+
+// {
+//   name:  "scala-compiler-doc",
+//   system: "ivy",
+//   set-version: ${vars.scala-compiler-doc.version.number}
+//   uri:    "ivy:org.scala-lang.modules#scala-compiler-doc_"${vars.scala.binary.version}";"${vars.scala-compiler-doc.version.number}
+// }, {
+//   name:  "scala-compiler-interactive",
+//   system: "ivy",
+//   set-version: ${vars.scala-compiler-interactive.version.number}
+//   uri:    "ivy:org.scala-lang.modules#scala-compiler-interactive_"${vars.scala.binary.version}";"${vars.scala-compiler-interactive.version.number}
+// },

--- a/versions.properties
+++ b/versions.properties
@@ -1,6 +1,17 @@
 maven.version.number=2.11.0-SNAPSHOT
 
-scala.binary.version=2.11.0-M6
-partest.version.number=1.0.0-RC7
-scala-xml.version.number=1.0.0-RC6
-scala-parser-combinators.version.number=1.0.0-RC4
+# the rest of this file comes from https://github.com/scala/scala/raw/master/versions.properties
+starr.version=2.11.0-M7
+starr.use.released=1
+
+# These are the versions of the modules that go with this release.
+# These properties are used during PR validation and in dbuild builds.
+scala.binary.version=2.11.0-M7
+partest.version.number=1.0.0-RC8
+scala-xml.version.number=1.0.0-RC7
+scala-parser-combinators.version.number=1.0.0-RC5
+scalacheck.version.number=1.11.1
+
+# TODO: modularize the compiler
+#scala-compiler-doc.version.number=1.0.0-RC1
+#scala-compiler-interactive.version.number=1.0.0-RC1


### PR DESCRIPTION
[Merge https://github.com/harrah/sbinary/pull/9 first!]

The only difference between the two builds is the vars section.
Ideally, these would be stored in properties file,
so that we can have only one dbuild config.

Build scalacheck (could also resolve it like scala-xml etc),
so we can run SBinary's test suite.

Also upgrade to M7 versions.properties.
