### PR TITLE
Add Scala 2.11.x build.

### DIFF
--- a/sbt-0.13.x-on-2.11.x
+++ b/sbt-0.13.x-on-2.11.x
@@ -7,7 +7,7 @@
   vars: {
     scala-version: "2.11.0-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
-    publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
+    publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.11"
     publish-repo: ${?PUBLISH_REPO}
     sbt-version: "0.13.2-M1"
     sbt-version: ${?SBT_VERSION}

--- a/sbt-0.13.x-on-2.11.x
+++ b/sbt-0.13.x-on-2.11.x
@@ -2,9 +2,10 @@
 #          Pleases do not modify without contacting them.
 # Nighlty job: https://jenkins-dbuild.typesafe.com:8499/job/sbt-0.13.x-nightly-for-ide-on-scala-2.10.x
 {
+  properties: "file://"${PWD}"/versions.properties"
   // Variables that may be external.  We have the defaults here.
   vars: {
-    scala-version: "2.10.4-SNAPSHOT"
+    scala-version: "2.11.0-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
     publish-repo: ${?PUBLISH_REPO}
@@ -15,30 +16,47 @@
   }
   build: {
     "projects":[
-      {
-        name:  "scala-lib",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-library;"${vars.scala-version}
-        set-version: ${vars.scala-version}
+       {
+        system: assemble
+        name:   scala2
+        deps.ignore: "org.scalacheck#scalacheck"
+        extra.parts.options: {
+          cross-version: standard
+          sbt-version: "0.13.0"
+        }
+        extra.parts.projects: [
+          {
+            name:  "scala-lib",
+            system: "ivy",
+            set-version: ${vars.maven.version.number}
+            uri:    "ivy:org.scala-lang#scala-library;"${vars.maven.version.number}
+          }, {
+            name:  "scala-reflect",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang#scala-reflect;"${vars.maven.version.number}
+            set-version: ${vars.maven.version.number}
+          }, {
+            name:  "scala-compiler",
+            system: "ivy",
+            set-version: ${vars.maven.version.number}
+            uri:    "ivy:org.scala-lang#scala-compiler;"${vars.maven.version.number}
+          },
+          {
+            name:  "scala-xml",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang.modules#scala-xml_"${vars.scala.binary.version}";"${vars.scala-xml.version.number}
+            set-version: "1.0-RC3" // required by sbinary?
+          }, {
+            name:  "scala-parser-combinators",
+            system: "ivy",
+            uri:    "ivy:org.scala-lang.modules#scala-parser-combinators_"${vars.scala.binary.version}";"${vars.scala-parser-combinators.version.number},
+            set-version: "1.0-RC1" // required by sbinary?
+          }
+        ]
       }, {
-        name:  "scala-compiler",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-compiler;"${vars.scala-version}
-        set-version: ${vars.scala-version}
-      }, {
-        name:  "scala-actors",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-actors;"${vars.scala-version}
-        set-version: ${vars.scala-version}
-      }, {
-        name:  "scala-reflect",
-        system: "ivy",
-        uri:    "ivy:org.scala-lang#scala-reflect;"${vars.scala-version}
-        set-version: ${vars.scala-version}
-      }, {
-        name:   "scalacheck",
-        system: "ivy",
-        uri:    "ivy:org.scalacheck#scalacheck_2.10;1.10.1"
+        name: scalacheck
+        extra.sbt-version: "0.13.0",
+        uri: "https://github.com/rickynils/scalacheck.git#1.11.1"
       }, {
         name:   "sbinary",
         uri:    "git://github.com/harrah/sbinary.git#master"


### PR DESCRIPTION
This should not break the current pr validation, but enable us to try out 0.13.2 builds for the IDE.

Review by @gkossakowski @adriaanm and @dragos just to be sure.
