### PR TITLE
Switch to Scala 2.10.5-SNAPSHOT builds

### DIFF
--- a/sbt-on-2.10.x
+++ b/sbt-on-2.10.x
@@ -4,7 +4,7 @@
 {
   // Variables that may be external.  We have the defaults here.
   vars: {
-    scala-version: "2.10.4-SNAPSHOT"
+    scala-version: "2.10.5-SNAPSHOT"
     scala-version: ${?SCALA_VERSION}
     publish-repo: "http://private-repo.typesafe.com/typesafe/ide-2.10"
     publish-repo: ${?PUBLISH_REPO}


### PR DESCRIPTION
Scala 2.10.4 final has been released. We are building 2.10.5-SNAPSHOTs now.
